### PR TITLE
Removed git alias

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -28,4 +28,3 @@ source $ZSH/oh-my-zsh.sh
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
 ulimit -n 1024
-alias g ="git"


### PR DESCRIPTION
I had attempted to use 'g' as a git alias before but that doesn't work and isn't necessary